### PR TITLE
update error_message formatting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-time-machine

--- a/test/recursive_match_test.exs
+++ b/test/recursive_match_test.exs
@@ -53,6 +53,7 @@ defmodule RecursiveMatchTest do
       refute match_r a, c
       refute match_r c, a
       assert match_r a.a, b.a
+      refute match_r %{c: nil}, %{}
     end
 
     test "structs" do
@@ -193,6 +194,51 @@ defmodule RecursiveMatchTest do
                    right: 2
                    """,
                    fn -> assert_match 1, 2 end
+
+      assert_raise ExUnit.AssertionError,
+                   """
+
+
+                   match (assert_match) failed
+                   left:  %{a: [1, 2]}
+                   right: %{a: [1, 2, 3]}
+                   """, fn -> assert_match %{a: [1, 2]}, %{a: [2, 1, 3]}, ignore_order: true end
+
+      assert_raise ExUnit.AssertionError,
+                   """
+
+
+                   match (assert_match) failed
+                   left:  %{a: [1, 2, 3]}
+                   right: %{a: [1, 2]}
+                   """, fn -> assert_match %{a: [1, 2, 3]}, %{a: [2, 1]}, ignore_order: true end
+
+      assert_raise ExUnit.AssertionError,
+                   """
+
+
+                   match (assert_match) failed
+                   left:  %{a: [1, 2]}
+                   right: %{a: [2, 1, 3]}
+                   """, fn -> assert_match %{a: [1, 2]}, %{a: [2, 1, 3]}, ignore_order: false end
+
+      assert_raise ExUnit.AssertionError,
+                   """
+
+
+                   match (assert_match) failed
+                   left:  %{a: [1, 2, 3]}
+                   right: %{a: [2, 1]}
+                   """, fn -> assert_match %{a: [1, 2, 3]}, %{a: [2, 1]}, ignore_order: false end
+
+      assert_raise ExUnit.AssertionError,
+                   """
+
+
+                   match (assert_match) failed
+                   left:  %{field1: 2}
+                   right: %{field1: 1}
+                   """, fn -> assert_match %{field1: 2}, %TestStruct{field1: 1, field2: %{a: 1}} end
     end
 
     test "variables" do


### PR DESCRIPTION
resolves #3 

1. Bug fix #3 
2. New error message formatting, to focus attention on what element are cause of the error:
* take into account `ignore_order: true` option and sort right arg in order with left arg in error message, to focus attention on what element are cause of the error

**Expression**: `assert_match [1, 2], [3, 2, 1], ignore_order: true`

**Before**:
<img width="500" alt="Снимок экрана 2021-03-06 в 00 03 02" src="https://user-images.githubusercontent.com/6092419/110173291-6dff7700-7e0f-11eb-93d1-17299679cabf.png">

  **After**:
<img width="512" alt="Снимок экрана 2021-03-06 в 00 02 35" src="https://user-images.githubusercontent.com/6092419/110173315-7657b200-7e0f-11eb-89ea-252329901906.png">

* format from struct to map right or left side in error_message, if only on of them is a struct

**Expression**: `assert_match %, ignore_order: true`

**Before**:
<img width="524" alt="Снимок экрана 2021-03-06 в 00 06 15" src="https://user-images.githubusercontent.com/6092419/110173578-dbaba300-7e0f-11eb-9fbe-e9f79291ab86.png">

**After**:
<img width="529" alt="Снимок экрана 2021-03-06 в 00 06 35" src="https://user-images.githubusercontent.com/6092419/110173617-e9f9bf00-7e0f-11eb-9234-d0fd677c305b.png">

